### PR TITLE
Downgrade Hive version from 2.1.0 to 2.0.1 due to bug in MSCK REPAIR …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM bde2020/hadoop-base:1.0.0-hadoop2.7.1
 MAINTAINER Yiannis Mouchakis <gmouchakis@iit.demokritos.gr>
 MAINTAINER Ivan Ermilov <ivan.s.ermilov@gmail.com>
 
-ENV HIVE_VERSION 2.1.0
+ENV HIVE_VERSION 2.0.1
 
 ENV HIVE_HOME /opt/hive
 ENV PATH $HIVE_HOME/bin:$PATH


### PR DESCRIPTION
2.1.0 has a nasty bug at time of writing.

https://issues.apache.org/jira/browse/HIVE-14798