### PR TITLE
Bump hive version from 2.0.1 to 2.1.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM bde2020/hadoop-base:1.0.0-hadoop2.7.1
 MAINTAINER Yiannis Mouchakis <gmouchakis@iit.demokritos.gr>
 MAINTAINER Ivan Ermilov <ivan.s.ermilov@gmail.com>
 
-ENV HIVE_VERSION 2.0.1
+ENV HIVE_VERSION 2.1.1
 
 ENV HIVE_HOME /opt/hive
 ENV PATH $HIVE_HOME/bin:$PATH


### PR DESCRIPTION
`2.0.1` tarball has been removed from the Apache site. `2.1.1` appears to work.